### PR TITLE
Update package.json to use the lastest mongoose (3.8.3)  

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "q": "~0.9.6",
-    "mongoose": "~3.6.15"
+    "mongoose": "~3.8.3"
   },
   "devDependencies": {
     "nodeunit": "*",


### PR DESCRIPTION
All the tests are still passing with the latest version of mongoose.
