### PR TITLE
Support a pluggable q implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
     "grunt": "latest",
     "grunt-contrib-jshint": "latest",
     "grunt-mocha-test": "latest"
+  },
+  "scripts": {
+    "test": "mocha tests/*_test.js"
   }
 }

--- a/tests/mongooseq_test.js
+++ b/tests/mongooseq_test.js
@@ -127,7 +127,6 @@ describe('mongooseq', function () {
     it('should aggregate', function (done) {
         // fix issue6
         var agg = UserModel.aggregate();
-        console.log('****************', agg);
         agg
             .match({name: {$regex: '^b.*' }})
             .qExec()

--- a/tests/spread_example_issue18.js
+++ b/tests/spread_example_issue18.js
@@ -1,6 +1,6 @@
 // try this too
 // var mongoose = require('./index')();
-var mongoose = require('./index')(require('mongoose'),{spread:true});
+var mongoose = require('..')(require('mongoose'),{spread:true});
 
 mongoose.connect('mongodb://localhost/test');
 


### PR DESCRIPTION
This PR adds the ability to use a supplied `Q` implementation for mongoose-q. 

The default behaviour remains the same. However, if you wish to use a different version of Q, you can supply it via the options hash:

```
var mongoose = require('mongoose-q')(require('mongoose'), { spread:true, q: require('q') });
```
### But why would you want this?

I'm currently experimenting with porting a large code base from Q to Bluebird and am considering using `q-bluebird` as a means of facilitating this. Having this option allows the Q implementation to be swapped with another, such as `q-bluebird`.

I also added the test script to `package.json` so that `npm test` runs as expected.
